### PR TITLE
Update Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ patch:
 
 
 qt_symlinks:
-	@for framework in $(FRAMEWORKS); do cd $(QT_BASE)/lib/$$framework; if [ ! -d Contents ]; then mkdir Contents; ln -s ./Resources/Info.plist Contents/Info.plist; fi; done
+	@for framework in $(FRAMEWORKS); do cd $(QT_BASE)/lib/$$framework; if [ ! -d Contents ]; then mkdir Contents; ln -s ../Resources/Info.plist Contents/Info.plist; fi; done
 
 config:
 	@cd synergy; ./hm.sh conf -g2 --mac-sdk $(SDKVER) --mac-identity test


### PR DESCRIPTION
Missing dot in relativ link for the qt Info.plist fix. 
With this change synergy build fine under works flawless under macOS Sierra (10.12.6).

Thanks for the effort making this Makefile!